### PR TITLE
Removed extract function and increase security

### DIFF
--- a/templates/sc-accordion.php
+++ b/templates/sc-accordion.php
@@ -37,7 +37,7 @@ add_shortcode('bs-accordion', 'bootscore_accordion');
 function bootscore_accordion($atts) {
 
   ob_start();
-  extract(shortcode_atts(array(
+  $atts = shortcode_atts(array(
     'type' => 'post',
     'order' => 'date',
     'orderby' => 'date',
@@ -47,19 +47,19 @@ function bootscore_accordion($atts) {
     'tax' => '',
     'terms' => '',
     'id' => ''
-  ), $atts));
+  ), $atts);
 
   $options = array(
-    'post_type' => $type,
-    'order' => $order,
-    'orderby' => $orderby,
-    'posts_per_page' => $posts,
-    'category_name' => $category,
-    'post_parent' => $post_parent,
+    'post_type' => sanitize_text_field($atts['type']),
+    'order' => sanitize_text_field($atts['order']),
+    'orderby' => sanitize_text_field($atts['orderby']),
+    'posts_per_page' => is_numeric($atts['posts']) ? (int) $atts['posts'] : -1,
+    'category_name' => sanitize_text_field($atts['category']),
+    'post_parent' => is_numeric($atts['post_parent']) ? (int) $atts['post_parent'] : '',
   );
 
-  $tax = trim($tax);
-  $terms = trim($terms);
+  $tax = trim(sanitize_text_field($atts['tax']));
+  $terms = trim(sanitize_text_field($atts['terms']));
   if ($tax != '' && $terms != '') {
     $terms = explode(',', $terms);
     $terms = array_map('trim', $terms);
@@ -73,8 +73,8 @@ function bootscore_accordion($atts) {
     ));
   }
 
-  if ($id != '') {
-    $ids = explode(',', $id);
+  if ($atts['id'] != '') {
+    $ids = explode(',', sanitize_text_field($atts['id']));
     $ids = array_map('intval', $ids);
     $ids = array_filter($ids);
     $ids = array_unique($ids);

--- a/templates/sc-grid.php
+++ b/templates/sc-grid.php
@@ -43,7 +43,7 @@ add_shortcode('bs-grid', 'bootscore_grid');
 function bootscore_grid($atts) {
 
   ob_start();
-  extract(shortcode_atts(array(
+  $atts = shortcode_atts(array(
     'type' => 'post',
     'order' => 'date',
     'orderby' => 'date',
@@ -56,19 +56,19 @@ function bootscore_grid($atts) {
     'excerpt' => 'true',
     'tags' => 'true',
     'categories' => 'true',
-  ), $atts));
+  ), $atts);
 
   $options = array(
-    'post_type' => $type,
-    'order' => $order,
-    'orderby' => $orderby,
-    'posts_per_page' => $posts,
-    'category_name' => $category,
-    'post_parent' => $post_parent,
+    'post_type' => sanitize_text_field($atts['type']),
+    'order' => sanitize_text_field($atts['order']),
+    'orderby' => sanitize_text_field($atts['orderby']),
+    'posts_per_page' => is_numeric($atts['posts']) ? (int) $atts['posts'] : -1,
+    'category_name' => sanitize_text_field($atts['category']),
+    'post_parent' => is_numeric($atts['post_parent']) ? (int) $atts['post_parent'] : '',
   );
 
-  $tax = trim($tax);
-  $terms = trim($terms);
+  $tax = trim(sanitize_text_field($atts['tax']));
+  $terms = trim(sanitize_text_field($atts['terms']));
   if ($tax != '' && $terms != '') {
     $terms = explode(',', $terms);
     $terms = array_map('trim', $terms);
@@ -82,8 +82,8 @@ function bootscore_grid($atts) {
     ));
   }
 
-  if ($id != '') {
-    $ids = explode(',', $id);
+  if ($atts['id'] != '') {
+    $ids = explode(',', sanitize_text_field($atts['id']));
     $ids = array_map('intval', $ids);
     $ids = array_filter($ids);
     $ids = array_unique($ids);
@@ -108,7 +108,7 @@ function bootscore_grid($atts) {
           
           <div class="card-body d-flex flex-column">
 
-            <?php if ($categories == 'true') : ?>
+            <?php if ($atts['categories'] == 'true') : ?>
               <?php bootscore_category_badge(); ?>
             <?php endif; ?>
 
@@ -127,7 +127,7 @@ function bootscore_grid($atts) {
               </p>
             <?php endif; ?>
 
-            <?php if ($excerpt == 'true') : ?>
+            <?php if ($atts['excerpt'] == 'true') : ?>
               <p class="card-text">
                 <a class="text-body text-decoration-none" href="<?php the_permalink(); ?>">
                   <?= strip_tags(get_the_excerpt()); ?>
@@ -141,7 +141,7 @@ function bootscore_grid($atts) {
               </a>
             </p>
 
-            <?php if ($tags == 'true') : ?>
+            <?php if ($atts['tags'] == 'true') : ?>
               <?php bootscore_tags(); ?>
             <?php endif; ?>
 

--- a/templates/sc-hero.php
+++ b/templates/sc-hero.php
@@ -43,7 +43,7 @@ add_shortcode('bs-hero', 'bootscore_hero');
 function bootscore_hero($atts) {
 
   ob_start();
-  extract(shortcode_atts(array(
+  $atts = shortcode_atts(array(
     'type' => 'post',
     'order' => 'date',
     'orderby' => 'date',
@@ -56,19 +56,19 @@ function bootscore_hero($atts) {
     'excerpt' => 'true',
     'tags' => 'true',
     'categories' => 'true',
-  ), $atts));
+  ), $atts);
 
   $options = array(
-    'post_type' => $type,
-    'order' => $order,
-    'orderby' => $orderby,
-    'posts_per_page' => $posts,
-    'category_name' => $category,
-    'post_parent' => $post_parent,
+    'post_type' => sanitize_text_field($atts['type']),
+    'order' => sanitize_text_field($atts['order']),
+    'orderby' => sanitize_text_field($atts['orderby']),
+    'posts_per_page' => is_numeric($atts['posts']) ? (int) $atts['posts'] : -1,
+    'category_name' => sanitize_text_field($atts['category']),
+    'post_parent' => is_numeric($atts['post_parent']) ? (int) $atts['post_parent'] : '',
   );
 
-  $tax = trim($tax);
-  $terms = trim($terms);
+  $tax = trim(sanitize_text_field($atts['tax']));
+  $terms = trim(sanitize_text_field($atts['terms']));
   if ($tax != '' && $terms != '') {
     $terms = explode(',', $terms);
     $terms = array_map('trim', $terms);
@@ -82,8 +82,8 @@ function bootscore_hero($atts) {
     ));
   }
 
-  if ($id != '') {
-    $ids = explode(',', $id);
+  if ($atts['id'] != '') {
+    $ids = explode(',', sanitize_text_field($atts['id']));
     $ids = array_map('intval', $ids);
     $ids = array_filter($ids);
     $ids = array_unique($ids);
@@ -101,7 +101,7 @@ function bootscore_hero($atts) {
           <div class="container h-100 d-flex flex-column">
             <div class="mt-auto text-white mb-5 text-center">
               <!-- Category badge -->
-              <?php if ($categories == 'true') : ?>
+              <?php if ($atts['categories'] == 'true') : ?>
                 <?php bootscore_category_badge(); ?>
               <?php endif; ?>
               <!-- Title -->
@@ -111,7 +111,7 @@ function bootscore_hero($atts) {
                 </a>
               </h2>
               <!-- Excerpt & Read more -->
-              <?php if ($excerpt == 'true') : ?>
+              <?php if ($atts['excerpt'] == 'true') : ?>
                 <p class="card-text">
                   <a class="text-white text-decoration-none" href="<?php the_permalink(); ?>">
                     <?= strip_tags(get_the_excerpt()); ?>
@@ -122,7 +122,7 @@ function bootscore_hero($atts) {
                 <a class="read-more btn btn-light" href="<?php the_permalink(); ?>"><?php _e('Read more »', 'bootscore'); ?></a>
               </p>
                 <!-- Tags -->
-              <?php if ($tags == 'true') : ?>
+              <?php if ($atts['tags'] == 'true') : ?>
                 <?php bootscore_tags(); ?>
               <?php endif; ?>
             </div>

--- a/templates/sc-list.php
+++ b/templates/sc-list.php
@@ -43,7 +43,7 @@ add_shortcode('bs-list', 'bootscore_list');
 function bootscore_list($atts) {
 
   ob_start();
-  extract(shortcode_atts(array(
+  $atts = shortcode_atts(array(
     'type' => 'post',
     'order' => 'date',
     'orderby' => 'date',
@@ -56,19 +56,19 @@ function bootscore_list($atts) {
     'excerpt' => 'true',
     'tags' => 'true',
     'categories' => 'true',
-  ), $atts));
+  ), $atts);
 
   $options = array(
-    'post_type' => $type,
-    'order' => $order,
-    'orderby' => $orderby,
-    'posts_per_page' => $posts,
-    'category_name' => $category,
-    'post_parent' => $post_parent,
+    'post_type' => sanitize_text_field($atts['type']),
+    'order' => sanitize_text_field($atts['order']),
+    'orderby' => sanitize_text_field($atts['orderby']),
+    'posts_per_page' => is_numeric($atts['posts']) ? (int) $atts['posts'] : -1,
+    'category_name' => sanitize_text_field($atts['category']),
+    'post_parent' => is_numeric($atts['post_parent']) ? (int) $atts['post_parent'] : '',
   );
 
-  $tax = trim($tax);
-  $terms = trim($terms);
+  $tax = trim(sanitize_text_field($atts['tax']));
+  $terms = trim(sanitize_text_field($atts['terms']));
   if ($tax != '' && $terms != '') {
     $terms = explode(',', $terms);
     $terms = array_map('trim', $terms);
@@ -82,8 +82,8 @@ function bootscore_list($atts) {
     ));
   }
 
-  if ($id != '') {
-    $ids = explode(',', $id);
+  if ($atts['id'] != '') {
+    $ids = explode(',', sanitize_text_field($atts['id']));
     $ids = array_map('intval', $ids);
     $ids = array_filter($ids);
     $ids = array_unique($ids);
@@ -109,7 +109,7 @@ function bootscore_list($atts) {
           <div class="col">
             <div class="card-body">
 
-              <?php if ($categories == 'true') : ?>
+              <?php if ($atts['categories'] == 'true') : ?>
                 <?php bootscore_category_badge(); ?>
               <?php endif; ?>
 
@@ -130,7 +130,7 @@ function bootscore_list($atts) {
 
               <p class="card-text">
                 <a class="text-body text-decoration-none" href="<?php the_permalink(); ?>">
-                  <?php if ($excerpt == 'true') : ?>
+                  <?php if ($atts['excerpt'] == 'true') : ?>
                     <p class="card-text">
                       <a class="text-body text-decoration-none" href="<?php the_permalink(); ?>">
                         <?= strip_tags(get_the_excerpt()); ?>
@@ -146,7 +146,7 @@ function bootscore_list($atts) {
                 </a>
               </p>
 
-              <?php if ($tags == 'true') : ?>
+              <?php if ($atts['tags'] == 'true') : ?>
                 <?php bootscore_tags(); ?>
               <?php endif; ?>
 

--- a/templates/sc-tabs.php
+++ b/templates/sc-tabs.php
@@ -37,7 +37,7 @@ add_shortcode('bs-tabs', 'bootscore_tabs');
 function bootscore_tabs($atts) {
 
   ob_start();
-  extract(shortcode_atts(array(
+  $atts = shortcode_atts(array(
     'type' => 'post',
     'order' => 'date',
     'orderby' => 'date',
@@ -47,19 +47,19 @@ function bootscore_tabs($atts) {
     'tax' => '',
     'terms' => '',
     'id' => ''
-  ), $atts));
+  ), $atts);
 
   $options = array(
-    'post_type' => $type,
-    'order' => $order,
-    'orderby' => $orderby,
-    'posts_per_page' => $posts,
-    'category_name' => $category,
-    'post_parent' => $post_parent,
+    'post_type' => sanitize_text_field($atts['type']),
+    'order' => sanitize_text_field($atts['order']),
+    'orderby' => sanitize_text_field($atts['orderby']),
+    'posts_per_page' => is_numeric($atts['posts']) ? (int) $atts['posts'] : -1,
+    'category_name' => sanitize_text_field($atts['category']),
+    'post_parent' => is_numeric($atts['post_parent']) ? (int) $atts['post_parent'] : '',
   );
 
-  $tax = trim($tax);
-  $terms = trim($terms);
+  $tax = trim(sanitize_text_field($atts['tax']));
+  $terms = trim(sanitize_text_field($atts['terms']));
   if ($tax != '' && $terms != '') {
     $terms = explode(',', $terms);
     $terms = array_map('trim', $terms);
@@ -73,8 +73,8 @@ function bootscore_tabs($atts) {
     ));
   }
 
-  if ($id != '') {
-    $ids = explode(',', $id);
+  if ($atts['id'] != '') {
+    $ids = explode(',', sanitize_text_field($atts['id']));
     $ids = array_map('intval', $ids);
     $ids = array_filter($ids);
     $ids = array_unique($ids);


### PR DESCRIPTION
Removed: extract function as it goes against WordPress Developer Standards
Security: Contributors and up have access to shortcodes, sanitized attributes to prevent malicious behavior.